### PR TITLE
Update module for Foundry VTT v13.346

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 3. A GM must be logged in for many of the Maestro functions to work due to underlying Foundry permission requirements.
 4. Game systems that do not include an Item Id reference in their item roll chat messages **cannot** be used with Item Tracks
 ---
+## [1.0.1] - 2025-07-27
+### Changed
+- Updated module version and README shield
+- Removed outdated game version check
+
 ## [1.0.0] - 2025-07-27
 > Updated for Foundry VTT v13
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![https://img.shields.io/badge/Foundry%20VTT-13.0=>13.346-green](https://img.shields.io/badge/Foundry%20VTT-13.0=>13.346-green)
+![https://img.shields.io/badge/Foundry%20VTT-13.346-green](https://img.shields.io/badge/Foundry%20VTT-13.346-green)
 
 ![GitHub downloads (latest)](https://img.shields.io/github/downloads-pre/death-save/maestro/latest/module.zip)
 [![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Install%20Base&query=package.installs&suffix=%&url=https://forge-vtt.com/api/bazaar/package/maestro&colorB=brightgreen)](https://forge-vtt.com/)

--- a/maestro.js
+++ b/maestro.js
@@ -54,7 +54,7 @@ export default class Conductor {
             window.setTimeout(Conductor._readyHookRegistrations, 500);
             //Conductor._readyHookRegistrations();
 
-            if (game.version >= "0.4.4" && Misc.isFirstGM()) {
+            if (Misc.isFirstGM()) {
                 game.maestro.migration = {};
                 migrationHandler();
             }

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
       "reddit": "u/etherboy12"
     }
   ],
-  "version":"1.0.0",
+  "version":"1.0.1",
   "minimumCoreVersion":"13",
   "compatibleCoreVersion":"13.346",
   "esmodules":["./maestro.js"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "maestro",
-  "version": "0.8.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@league-of-foundry-developers/foundry-vtt-types": "^9.238.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Adds new audio features to Foundry VTT",
   "main": "maestro.js",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove outdated Foundry version check
- bump module version to 1.0.1
- update manifest and docs for Foundry VTT 13.346